### PR TITLE
Add Docker support to install the service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openeye/oetk_py3
+
+COPY . /tmp/oe-microservices
+RUN pip install Flask gunicorn && \
+    cd /tmp/oe-microservices && python setup.py install
+EXPOSE 5000
+
+CMD gunicorn oemicroservices.api:app --bind 0.0.0.0:5000 --threads 5
+#If you want to run tests instead of running the app, uncomment this CMD instead of the maine one
+#CMD cd /tmp/oe-microservices && python setup.py test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To uninstall
 
 Tested in Anaconda Python 2.7.9 and 3.4.3.
 
+## Running in Docker
+
+It's not on Dockerhub yet, so you need to build the image first:
+`docker build -t oe-microservices .`
+And then run: `docker run -p 5000:5000 -v /path/to/oe_license.txt_:/tmp/oe_license.txt:ro oe-microservices`
+
 ## Usage
 
 ### Standalone Application


### PR DESCRIPTION
Right now it installs OE Tookits on raw Ubuntu. But hopefully soon
OE Tookits is going to be available as its own Docker image. It
depends on this PR: https://github.com/oess/docker-images/pull/1
